### PR TITLE
`calibrate_thresholds.py` script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ bitstring = "^3.1.9"
 PyAutoGUI = "^0.9.53"
 httpx = "^0.21.1"
 pyserial-asyncio = "^0.6"
+legacy-cgi = "^2.6.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ PyAutoGUI = "^0.9.53"
 httpx = "^0.21.1"
 pyserial-asyncio = "^0.6"
 legacy-cgi = "^2.6.3"
+sounddevice = "^0.5.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -12,6 +12,7 @@ import statistics
 import time
 import numpy
 import sounddevice
+import serial
 from typing import List
 
 # Sound generation settings
@@ -20,11 +21,6 @@ duration = 0.2
 frequency = 392 # Hz
 
 samples = numpy.sin(2 * numpy.pi * numpy.arange(fs * duration) * frequency / fs)
-
-try:
-    import serial  # pyserial
-except ImportError:
-    raise SystemExit("This script requires pyserial. Install with:  pip install pyserial")
 
 FILES = ['A','B','C','D','E','F','G','H']
 RANKS = ['1','2','3','4','5','6','7','8']
@@ -89,15 +85,22 @@ def push_threshold_global(ser: serial.Serial, value: int):
         print(f"\n[WARN] Failed to push threshold to board: {e}")
 
 
-def push_threshold_individual(ser: serial.Serial, value: List[int]):
+def push_threshold_individual(ser: serial.Serial, values: List[int]):
     """Apply individual thresholds to the LiBoard via its calibration mode."""
+
+    if len(values) != 64:
+        raise ValueError("Need exactly 64 threshold values")
+
+    # Format: plain CSV (no brackets/spaces required; spaces tolerated by Arduino)
+    csv_line = ",".join(str(int(v)) for v in values) + "\n"
+
     try:
         ser.reset_input_buffer()
         ser.write(b'c')                 # tell board to enter calibration mode
         ser.flush()
         time.sleep(0.1)                 # small delay to let it switch
 
-        ser.write(f"{value}\n".encode("ascii"))  # send threshold value
+        ser.write(csv_line.encode("ascii"))  # send threshold value
         ser.flush()
         time.sleep(0.2)                 # brief wait for Arduino to finish
         print("\n[OK] Pushed individual thresholds to board.")
@@ -225,16 +228,18 @@ def main():
         print(f"\nApplying global threshold ({global_threshold}) to Liboard...")
         push_threshold_global(ser, global_threshold)
         
-
     else:
-        print("unsigned short THRESHOLD[64] = {")
         # Output in A1–H1, A2–H2, … A8–H8 order
-        result = []
+        individual_thresholds = []
         for rank in range(8):      # ranks 1–8
             for file in range(8):  # files A–H
                 idx = rank * 8 + file
-                result.append(thresholds[idx])
-        print(','.join(str(t) for t in result))
+                individual_thresholds.append(thresholds[idx])
+    
+        print("\nApplying the following thresholds to Liboard...:")
+        print(",".join(str(v) for v in individual_thresholds))
+        push_threshold_individual(ser, individual_thresholds)
+
 
     ser.close()
     print("\nAll done.")

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -170,6 +170,14 @@ def main():
 
     time.sleep(2.0)
 
+    # Enter quiet mode to turn of Bitboard output
+    try:
+        ser.reset_input_buffer()
+        ser.write(b'q') 
+        ser.flush()
+    except Exception:
+        pass
+
     # Detect board threshold mode
     try:
         th_vals, board_is_global = _read_thresholds(ser)
@@ -291,6 +299,13 @@ def main():
         print(",".join(str(v) for v in individual_thresholds))
         push_threshold_individual(ser, individual_thresholds)
 
+    # Exit Quiet Mode to resume bitboard output
+    try:
+        ser.reset_input_buffer()
+        ser.write(b'q')
+        ser.flush()
+    except Exception:
+        pass
 
     ser.close()
     print("\nAll done.")

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -10,7 +10,16 @@ wait 1 second to capture the lowest (occupied) value, then print a THRESHOLD[64]
 import argparse
 import statistics
 import time
+import numpy
+import sounddevice
 from typing import List
+
+# Sound generation settings
+fs = 44100 # sample rate
+duration = 0.2
+frequency = 392 # Hz
+
+samples = numpy.sin(2 * numpy.pi * numpy.arange(fs * duration) * frequency / fs)
 
 try:
     import serial  # pyserial
@@ -122,6 +131,8 @@ def main():
     print("Collecting baseline (unoccupied) readings...")
     empty = _average_readings(ser, args.samples, args.delay)
     print("Baseline captured.\n")
+    sounddevice.play(samples, fs)
+    sounddevice.wait()
 
     occupied = [0] * 64
     thresholds = [0] * 64
@@ -130,6 +141,8 @@ def main():
         print(f"\n=== Square {sq} ===")
         occ_val = _wait_for_piece(ser, i, empty[i])
         occupied[i] = occ_val
+        sounddevice.play(samples, fs)
+        sounddevice.wait()
         print(f"  Empty: {empty[i]:>4} | Occupied: {occupied[i]:>4}")
 
         print("  Waiting for removal...")

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -156,7 +156,9 @@ def main():
     print("unsigned short THRESHOLD[64] = {")
     for r in range(8):
         row = ', '.join(f"{t:4}" for t in thresholds[r*8:(r+1)*8])
-        print(f"  // Rank {r+1}\n  {row},")
+        file_letter = FILES[r] # A..H
+        squares_range = f"{file_letter}1-{file_letter}8"
+        print(f"  // {squares_range}\n {row},")
     print("};")
 
     ser.close()

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -1,0 +1,154 @@
+#! /usr/bin/python3
+
+"""Automatically calibrate LiBoard photoresistor thresholds via USB.
+
+Each '?' sent to the board returns one CSV line of 64 ADC values.
+We take averages for empty and automatically detect when a piece is placed,
+wait 1 second to capture the lowest (occupied) value, then print a THRESHOLD[64].
+"""
+
+import argparse
+import statistics
+import time
+from typing import List
+
+try:
+    import serial  # pyserial
+except ImportError:
+    raise SystemExit("This script requires pyserial. Install with:  pip install pyserial")
+
+FILES = ['A','B','C','D','E','F','G','H']
+RANKS = ['1','2','3','4','5','6','7','8']
+SQUARES = [f"{f}{r}" for r in RANKS for f in FILES]  # A1..H8 order
+
+
+def _read_snapshot(ser: serial.Serial, timeout_s: float = 1.0, retries: int = 3) -> List[int]:
+    """Request one CSV snapshot ('?') and parse 64 ints, retrying if needed."""
+    for attempt in range(retries):
+        try:
+            ser.reset_input_buffer()
+            ser.write(b'?')
+            ser.flush()
+
+            end = time.time() + timeout_s
+            while time.time() < end:
+                line = ser.readline()
+                if not line:
+                    continue
+                try:
+                    text = line.decode('ascii', errors='strict').strip()
+                except UnicodeDecodeError:
+                    continue
+                parts = text.split(',')
+                if len(parts) != 64:
+                    continue
+                try:
+                    vals = [int(p) for p in parts]
+                except ValueError:
+                    continue
+                return vals
+        except Exception:
+            pass  # ignore transient serial errors
+        print("  [!] CSV read timeout — retrying...")
+        time.sleep(1.0)
+
+    raise TimeoutError("Failed to get CSV snapshot after multiple retries")
+
+
+def _average_readings(ser: serial.Serial, samples: int, delay_s: float) -> List[int]:
+    """Average N snapshots."""
+    buckets = [[] for _ in range(64)]
+    for _ in range(samples):
+        vals = _read_snapshot(ser)
+        for i, v in enumerate(vals):
+            buckets[i].append(v)
+        time.sleep(delay_s)
+    return [int(statistics.mean(b)) for b in buckets]
+
+
+def _wait_for_piece(ser: serial.Serial, idx: int, baseline: int, drop_threshold: int = 50) -> int:
+    """Wait for the ADC value at square `idx` to drop significantly from baseline, then sample for 1s."""
+    print("  Waiting for piece placement...")
+    while True:
+        vals = _read_snapshot(ser)
+        v = vals[idx]
+        if baseline - v > drop_threshold:
+            print("  Piece detected, waiting 1s to stabilize...")
+            t_end = time.time() + 1.0
+            lowest = v
+            while time.time() < t_end:
+                vals2 = _read_snapshot(ser)
+                v2 = vals2[idx]
+                if v2 < lowest:
+                    lowest = v2
+                time.sleep(0.05)
+            return lowest
+        time.sleep(0.05)
+
+
+def _wait_for_removal(ser: serial.Serial, idx: int, baseline: int, tolerance: int = 30):
+    """Wait until the ADC value returns near baseline (piece removed)."""
+    while True:
+        vals = _read_snapshot(ser)
+        v = vals[idx]
+        if abs(v - baseline) < tolerance:
+            return
+        time.sleep(0.05)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('-p', '--port', default='/dev/ttyACM0',
+                        help='Serial port the board is connected to')
+    parser.add_argument('-b', '--baud-rate', default=9600, type=int,
+                        help="Board's baud rate")
+    parser.add_argument('--samples', default=15, type=int,
+                        help='Snapshots to average for empty baseline')
+    parser.add_argument('--delay', default=0.05, type=float,
+                        help='Delay between snapshots (s)')
+    args = parser.parse_args()
+
+    print(f"Connecting to LiBoard on {args.port} at {args.baud_rate} baud...")
+    try:
+        ser = serial.Serial(args.port, args.baud_rate, timeout=1)
+    except serial.SerialException as e:
+        raise SystemExit(f"Could not open port {args.port}: {e}")
+
+    time.sleep(2.0)
+    input("\nMake sure the board is COMPLETELY EMPTY, then press Enter...")
+    print("Collecting baseline (unoccupied) readings...")
+    empty = _average_readings(ser, args.samples, args.delay)
+    print("Baseline captured.\n")
+
+    occupied = [0] * 64
+    thresholds = [0] * 64
+
+    for i, sq in enumerate(SQUARES):
+        print(f"\n=== Square {sq} ===")
+        occ_val = _wait_for_piece(ser, i, empty[i])
+        occupied[i] = occ_val
+        print(f"  Empty: {empty[i]:>4} | Occupied: {occupied[i]:>4}")
+
+        print("  Waiting for removal...")
+        _wait_for_removal(ser, i, empty[i])
+
+        hi, lo = max(empty[i], occupied[i]), min(empty[i], occupied[i])
+        thresholds[i] = int((hi + lo) / 2)
+
+    print("\nCalibration complete!\n")
+    print("// Paste this into your firmware (.ino):")
+    print("unsigned short THRESHOLD[64] = {")
+    for r in range(8):
+        row = ', '.join(f"{t:4}" for t in thresholds[r*8:(r+1)*8])
+        print(f"  // Rank {r+1}\n  {row},")
+    print("};")
+
+    ser.close()
+    print("\nAll done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -240,8 +240,6 @@ def main():
 
             print(f"  {sq}: Empty: {empty[idx]:>4} | Occupied: {occupied[idx]:>4}")
 
-            input("Remove the piece, then press Enter to continue...")
-
             hi, lo = max(empty[idx], occupied[idx]), min(empty[idx], occupied[idx])
             thresholds[idx] = int((hi + lo) / 2)
 
@@ -264,9 +262,6 @@ def main():
                 sq_label = f"{FILES[j]}{rank}"
                 occupied[idx] = vals[idx]
                 print(f"  {sq_label}: Empty: {empty[idx]:>4} | Occupied: {occupied[idx]:>4}")
-
-            # ask user to clear this rank before proceeding
-            input("Remove pieces from this rank, then press Enter to continue...")
 
             # Compute thresholds for this rank
             for idx in indices:


### PR DESCRIPTION
This script runs through the board and gets the average threshold reading for each photoresistor when a piece is on the square. This is useful when finding the correct threshold for the particular lighting and not relying on trial and error.

The process is as follows:

1. Empty chessboard to get unoccupied readings
2. Place 8 pieces on each rank, starting with A1 to A8
3. Collect occupied reading for rank
4. Repeat steps 2 and 3 until done

It has both a global and individual mode that outputs a threshold value the user can paste into there `.ino` file. 
Example:
```c
// Individual
unsigned short THRESHOLD[64] = {
  // A1-A8
  436,  411,  458,  523,  405,  396,  539,  341,
  // B1-B8
  475,  471,  454,  470,  565,  485,  398,  468,
  // C1-C8
  322,  299,  327,  272,  340,  299,  304,  339,
  // D1-D8
  312,  355,  313,  333,  331,  344,  293,  467,
  // E1-E8
  692,  718,  719,  726,  725,  681,  722,  736,
  // F1-F8
  726,  711,  698,  690,  733,  727,  723,  682,
  // G1-G8
  576,  580,  604,  667,  652,  596,  657,  659,
  // H1-H8
  525,  488,  479,  647,  644,  660,  559,  656,
};
```
```c
// Global
const unsigned short THRESHOLD = 496;
```

You can toggle between which mode you want to use by editing this variable before uploading firmware:
```c
// !!! choose mode: 1 = global single value, 0 = per-square array !!!
#define USE_GLOBAL_THRESHOLD 1
```

The script also has an optional `-s, --squares` flag which the user can skip the calibration by rank and instead do it by square. This is useful if one or two sensors need adjusting without having to recalibrate the whole board.
Example:
```bash
// Calibrates squares A3 and D5
python calibrate_thresholds.py -s a3,d5
```